### PR TITLE
Add category to TOC

### DIFF
--- a/DialogueUI.toc
+++ b/DialogueUI.toc
@@ -11,6 +11,17 @@
 ## IconTexture: Interface\AddOns\DialogueUI\Art\Icons\Logo
 ## AddonCompartmentFunc: DialogueUI_ShowSettingsFrame
 
+## Category-enUS: Quests
+## Category-deDE: Quests
+## Category-esES: Misiones
+## Category-esMX: Misiones
+## Category-frFR: Quêtes
+## Category-itIT: Missioni
+## Category-koKR: 퀘스트
+## Category-ptBR: Missões
+## Category-ruRU: Задания
+## Category-zhCN: 任务
+## Category-zhTW: 任務
 
 Initialization.lua
 Locales\Localization.xml


### PR DESCRIPTION
Since Patch 11.1, it is possible to categorize an addon and group them. More info: https://warcraft.wiki.gg/wiki/Patch_11.1.0/API_changes

I think the “Quests” category is the most suitable. What do you think?