### PR TITLE
Fix when SetMultiLanguageQuestFont does not reset font

### DIFF
--- a/Code/Utility/FontUtil.lua
+++ b/Code/Utility/FontUtil.lua
@@ -380,17 +380,14 @@ do
     function FontUtil:SetOverrideFont(fontObjectName, file, isRequery)
         if FONT_OBJECT_HEIGHT[fontObjectName] then
             if file then
-                local success = self.TestFont:SetFont(file, 10, "");
-                if success then
-                    OVERRIDE_FONT[fontObjectName] = file;
-                else
-                    if not isRequery then
-                        C_Timer.After(0.2, function()
-                            self:SetOverrideFont(fontObjectName, file, true);
-                        end);
-                    end
-                    return
+                self.TestFont:SetFont(file, 10, "");
+                OVERRIDE_FONT[fontObjectName] = file;
+                if not isRequery then
+                    C_Timer.After(0.2, function()
+                        self:SetOverrideFont(fontObjectName, file, true);
+                    end);
                 end
+                return
             else
                 OVERRIDE_FONT[fontObjectName] = nil;
             end
@@ -400,7 +397,8 @@ do
     end
 
     function FontUtil:SetMultiLanguageQuestFont(file)
-        return self:SetOverrideFont("DUIFont_Quest_MultiLanguage", file);
+        self:SetOverrideFont("DUIFont_Quest_MultiLanguage", file);
+        FontUtil:SetFontByFile(file)
     end
 end
 


### PR DESCRIPTION
Hi,

what i know, the SetFont does not return value. So it never set OVERRIDE_FONT. Or am i wrong?
Than it does not set the correct font, it have still the font from Fonts.xml.

I hope this change is fine. If not, could you please check the problem? Or suggest better solution?

Thanks.