### PR TITLE
Fix icon for equipping items after quest rewards.

### DIFF
--- a/Code/Dialogue/UITemplates.lua
+++ b/Code/Dialogue/UITemplates.lua
@@ -2834,9 +2834,9 @@ do  --Settings, CallbackRegistry
             HotkeyIcons.Esc = nil;
             HotkeyIcons.Shift = nil;
             GAME_PAD_CONFIRM_KEY = nil;
-            HotkeyIcons.Confirm = HotkeyIcons["SPACE"];
+            HotkeyIcons.Confirm = nil;
             HotkeyIcons.Cancel = nil;
-            HotkeyIcons.Action = HotkeyIcons["SPACE"];
+            HotkeyIcons.Action = nil;
             HotkeyIcons.Mod = nil;
         end
 


### PR DESCRIPTION
When a new, better item is given by a quest and the equip-frame is shown (and enabled), the spacebar icon is shown, even though a different key is set for interacting with the frame (i.e. the F key). This commit fixes this by using the correct icon.