### PR TITLE
Fix TTS autoplay continuing after leaving dialogue before playback starts

### DIFF
--- a/Code/Utility/TTS.lua
+++ b/Code/Utility/TTS.lua
@@ -200,7 +200,6 @@ function TTSUtil:SpeakText(segment)
     self:RegisterEvent("VOICE_CHAT_TTS_PLAYBACK_STARTED");
     local allowOverlappedSpeech = false;
     C_VoiceChat_SpeakText(segment.voiceID, segment.text, self.rate, self.volume, allowOverlappedSpeech);
-    self.nextSegment = nil;
 end
 
 function TTSUtil:ReadCurrentDialogue(fromAutoPlay)

--- a/Code/Utility/TTS.lua
+++ b/Code/Utility/TTS.lua
@@ -200,6 +200,7 @@ function TTSUtil:SpeakText(segment)
     self:RegisterEvent("VOICE_CHAT_TTS_PLAYBACK_STARTED");
     local allowOverlappedSpeech = false;
     C_VoiceChat_SpeakText(segment.voiceID, segment.text, self.rate, self.volume, allowOverlappedSpeech);
+    self.nextSegment = nil;
 end
 
 function TTSUtil:ReadCurrentDialogue(fromAutoPlay)
@@ -369,7 +370,7 @@ function TTSUtil:VOICE_CHAT_TTS_PLAYBACK_FINISHED(numConsumers, utteranceID, des
 end
 
 function TTSUtil:StopLastTTS()
-    if self.utteranceID then
+    if self.utteranceID or self.queue or self.nextSegment then
         self:Clear();
     end
 end


### PR DESCRIPTION
Previously, StopLastTTS() only cleared active playback after utteranceID was assigned. If a dialogue was closed while TTS was queued or pending before VOICE_CHAT_TTS_PLAYBACK_STARTED fired, the speech could continue playing.

This updates StopLastTTS() to clear pending TTS states as well as active playback.

Closes https://github.com/Peterodox/YUI-Dialogue/issues/200