### PR TITLE
1.0.5

### DIFF
--- a/Code/Camera.lua
+++ b/Code/Camera.lua
@@ -55,6 +55,15 @@ local IsDynamicFlying; -- Avoid changing FOV when mounted to prevent FOV stuck a
 if CameraUtil.isMidnight then
     SetUIVisibility = function(state)
         UIParent:SetShown(state);
+        --[[
+        if state then
+            UIParent:SetAlpha(1);
+            Minimap:Show();
+        else
+            UIParent:SetAlpha(0);
+            Minimap:Hide();
+        end
+        --]]
     end
 
     IsDynamicFlying = function()
@@ -1082,8 +1091,30 @@ do  --Update Parameters Based On Player Form
 end
 
 
-do  --Disable EXPERIMENTAL_CVAR_CONFIRMATION_NEEDED due to 12.1.0 changes
+do  -- For 12.1.0: Disable EXPERIMENTAL_CVAR_CONFIRMATION_NEEDED due to changes.
     if GameEvent and GameEvent.UnregisterInternalEvent then
         GameEvent.UnregisterInternalEvent("EXPERIMENTAL_CVAR_CONFIRMATION_NEEDED");
     end
+end
+
+
+do  -- For 12.1.0: Disable "CloseAllWindows()" for "UI.TopLevelParentShown" (See Interface/AddOns/Blizzard_Game/Shared/Game.lua)
+    -- Otherwise UIs like MerchantFrame will not appear if they are opened while the UIParent is hidden.
+    -- This approach might taint EventRegistry, but it's the best workaround for now.
+    -- Systems that uses "UI.TopLevelParentShown" seem to be of low importance:
+    -- LowHealthFrame and ActionStatus (the container that shows Screen Captured)
+
+    local function UnregisterCallbackWidthNoOwner(callbackType, event)
+        if EventRegistry.callbackTables and EventRegistry.callbackTables[callbackType] then
+            local callbacks = EventRegistry.callbackTables[callbackType][event];
+            if callbacks then
+                for owner in pairs(EventRegistry.callbackTables[callbackType][event]) do
+                    if type(owner) == "number" then
+                        callbacks[owner] = nil;
+                    end
+                end
+            end
+        end
+    end
+    UnregisterCallbackWidthNoOwner(2, "UI.TopLevelParentShown");
 end

--- a/Code/Camera.lua
+++ b/Code/Camera.lua
@@ -1080,3 +1080,10 @@ do  --Update Parameters Based On Player Form
         self.updator:SetScript("OnUpdate", Updator_OnUpdate);
     end
 end
+
+
+do  --Disable EXPERIMENTAL_CVAR_CONFIRMATION_NEEDED due to 12.1.0 changes
+    if GameEvent and GameEvent.UnregisterInternalEvent then
+        GameEvent.UnregisterInternalEvent("EXPERIMENTAL_CVAR_CONFIRMATION_NEEDED");
+    end
+end

--- a/Code/Dialogue/UITemplates.lua
+++ b/Code/Dialogue/UITemplates.lua
@@ -1441,6 +1441,28 @@ function DUIDialogItemButtonMixin:UpdatePixel(scale)
     API.UpdateTextureSliceScale(self.ItemBorder);
 end
 
+local function CanPreviewLink(link)
+    if not link then return false; end
+
+    if API.IsDressableItem(link) then
+        return true
+    else
+        local itemID = C_Item.GetItemIDForItemInfo(link);
+        if itemID then
+            local canPreview;
+            if C_Item.IsDecorItem and C_Item.IsDecorItem(link) then
+                canPreview = true;
+            elseif C_MountJournal and C_MountJournal.GetMountFromItem and C_MountJournal.GetMountFromItem(itemID) then
+                canPreview = true;
+            elseif C_PetJournal and C_PetJournal.GetPetInfoByItemID then
+                local _, _, _, creatureID, _, _, _, _, _, _, _, displayID = C_PetJournal.GetPetInfoByItemID(itemID);
+                canPreview = creatureID and displayID and true;
+            end
+            return canPreview
+        end
+    end
+end
+
 function DUIDialogItemButtonMixin:OnClick(button)
     if button == "RightButton" and addon.GetDBBool("RightClickToCloseUI") then
         addon.DialogueUI:Hide();
@@ -1463,11 +1485,7 @@ function DUIDialogItemButtonMixin:OnClick(button)
                     return
                 end
             elseif modifiedAction == 2 then
-                if API.IsDressableItem(link) then
-                    CallbackRegistry:Trigger("PlayerInteraction.ShowUI", true);
-                    DressUpVisual(link);
-                    return
-                elseif C_Item.IsDecorItem and C_Item.IsDecorItem(link) then
+                if CanPreviewLink(link) then
                     CallbackRegistry:Trigger("PlayerInteraction.ShowUI", true);
                     DressUpLink(link);
                     return
@@ -1899,15 +1917,7 @@ function DUIDialogItemButtonMixin:OnEnter()
     local canPreviewLink;
     local link = self.objectType == "item" and GetQuestItemLink(self.type, self.index);
 
-    if link then
-        if API.IsDressableItem(link) then
-            canPreviewLink = true;
-        elseif C_Item.IsDecorItem and C_Item.IsDecorItem(link) then
-            canPreviewLink = true;
-        end
-    end
-
-    if canPreviewLink then
+    if CanPreviewLink(link) then
         self:RegisterEvent("MODIFIER_STATE_CHANGED");
         self:SetScript("OnEvent", self.OnEvent);
         if IsControlKeyDown() then

--- a/Code/Dialogue/UITemplates.lua
+++ b/Code/Dialogue/UITemplates.lua
@@ -121,9 +121,8 @@ local function OnClickFunc_SelectOption(gossipButton)
     gossipButton.owner:SetConsumeGossipClose(false);
     gossipButton.owner:SetSelectedGossipIndex(gossipButton.id);     --For Dialogue History: Grey out other buttons
 
-    --Classic
-    if gossipButton.isSpecialIcon or GossipDataProvider:DoesOptionOpenUI(gossipButton.gossipOptionID) then
-        CallbackRegistry:Trigger("PlayerInteraction.ShowUI", true);
+    if gossipButton.shouldShowUIOnClick or GossipDataProvider:DoesOptionOpenUI(gossipButton.gossipOptionID) then
+        CallbackRegistry:Trigger("PlayerInteraction.ShowUI", true); -- Some UI breaks if shown while UIParent is hidden
     end
 
     C_GossipInfo.SelectOptionByIndex(gossipButton.id);
@@ -363,6 +362,7 @@ function DUIDialogOptionButtonMixin:SetGossip(data, hotkey)
     self.gossipOptionID = data.gossipOptionID;
 
     local name = GossipDataProvider:GetOverrideName(self.gossipOptionID) or data.name;
+    local shouldShowUIOnClick;
 
     local hasColor = false;
     name, hasColor = ThemeUtil:AdjustTextColor(name);
@@ -372,6 +372,7 @@ function DUIDialogOptionButtonMixin:SetGossip(data, hotkey)
     elseif data.flags == 1 then
         self.Icon:SetTexture(GossipDataProvider:GetGossipIcon(data.icon, "Gossip Quest"));
     elseif data.flags == 4 or data.flags == 5 then
+        shouldShowUIOnClick = true;
         self.Icon:SetTexture(GossipDataProvider:GetGossipIcon(data.icon, "Gossip Movie"));
     else
         if data.overrideIconID then
@@ -397,8 +398,7 @@ function DUIDialogOptionButtonMixin:SetGossip(data, hotkey)
     self:SetButtonArt(0);
     self:Enable();
 
-    --Classic
-    self.isSpecialIcon = data.icon ~= 132053;
+    self.shouldShowUIOnClick = shouldShowUIOnClick or data.icon ~= 132053; --Classic Trainer
 end
 
 function DUIDialogOptionButtonMixin:SetGossipHint(data, hotkey)
@@ -422,7 +422,7 @@ function DUIDialogOptionButtonMixin:SetGossipHint(data, hotkey)
     self:SetButtonText(name, false);
     self:SetButtonArt(0);
     self:Enable();
-    self.isSpecialIcon = false;
+    self.shouldShowUIOnClick = false;
 end
 
 function DUIDialogOptionButtonMixin:FlagAsPreviousGossip(selectedGossipID)

--- a/Code/GossipData/GossipData_AutoSelect.lua
+++ b/Code/GossipData/GossipData_AutoSelect.lua
@@ -90,6 +90,7 @@ local AutoSelectGossip = {
     [120132] = 1,           --Partially-Chewed Goblin, (Delve)
     [131312] = 1,           --Balga Wicksfix, (Delve)
     [120255] = 1,           --Vetiverian, (Delve)
+    [139585] = 1,           --Minchi (Delve)
 };
 
 local function IsAutoSelectOption(gossipOptionID, onlyOption)

--- a/Code/GossipData/GossipData_ShowUI.lua
+++ b/Code/GossipData/GossipData_ShowUI.lua
@@ -22,6 +22,8 @@ local ShowUIGossip = {
     [136916] = true,    --Delver's Guide (Show UI immediately otherwise Journey UI won't open Delves)
     [138803] = true,    --<Peruse its pages.> Index of Anguish
     [138824] = true,    --Ritual Site Reports
+    [139923] = true,    --<Review information on your current delve progress.> (Season 2)
+    [141839] = true,    --<Recite from the Corrosive Codex.>
 };
 
 function GossipDataProvider:DoesOptionOpenUI(gossipOptionID)
@@ -32,15 +34,19 @@ function GossipDataProvider:DoesOptionOpenUI(gossipOptionID)
     return gossipOptionID and ShowUIGossip[gossipOptionID] == true
 end
 
-if PetStableFrame then
+if true then -- PetStableFrame
     --Classic: PetStableFrame and ClassTrainerFrame become unresponsive if then are brought up when IsVisible() == false
+    --Retail:  12.1 Altar of Corrosion requires the UI to be shown.
+
     local ShoUIInteractType = {
         ["Cursor Stablemaster"] = true,
         ["Cursor Trainer"] = true,
+        ["Cursor Crosshair_Trainer_64"] = true,
     };
 
     function GossipDataProvider:DoesOptionOpenUI(gossipOptionID)
         local interactType = GetInteractType("npc");
+
         if interactType and ShoUIInteractType[interactType] then
             return true
         end

--- a/DialogueUI.toc
+++ b/DialogueUI.toc
@@ -1,6 +1,6 @@
 ## X-Expansion: MAINLINE
 ## Interface: 120007, 120100
-## Version: 1.0.4
+## Version: 1.0.5
 
 ## Title: Dialogue UI
 

--- a/DialogueUI_Cata.toc
+++ b/DialogueUI_Cata.toc
@@ -1,6 +1,6 @@
 ## X-Expansion: CATA
 ## Interface: 40402
-## Version: 1.0.4
+## Version: 1.0.5
 
 ## Title: Dialogue UI
 

--- a/DialogueUI_Mists.toc
+++ b/DialogueUI_Mists.toc
@@ -1,6 +1,6 @@
 ## X-Expansion: MISTS
 ## Interface: 50504
-## Version: 1.0.4
+## Version: 1.0.5
 
 ## Title: Dialogue UI
 

--- a/DialogueUI_TBC.toc
+++ b/DialogueUI_TBC.toc
@@ -1,6 +1,6 @@
 ## X-Expansion: TBC
 ## Interface: 20506
-## Version: 1.0.4
+## Version: 1.0.5
 
 ## Title: Dialogue UI
 

--- a/DialogueUI_Vanilla.toc
+++ b/DialogueUI_Vanilla.toc
@@ -1,6 +1,6 @@
 ## X-Expansion: VANILLA
 ## Interface: 11509
-## Version: 1.0.4
+## Version: 1.0.5
 
 ## Title: Dialogue UI
 

--- a/DialogueUI_Wrath.toc
+++ b/DialogueUI_Wrath.toc
@@ -1,6 +1,6 @@
 ## X-Expansion: WRATH
-## Interface: 30405
-## Version: 1.0.3
+## Interface: 30405, 38002
+## Version: 1.0.5
 
 ## Title: Dialogue UI
 

--- a/Initialization.lua
+++ b/Initialization.lua
@@ -1,5 +1,5 @@
-local VERSION_TEXT = "v1.0.4 f";
-local VERSION_DATE = 1785200000;
+local VERSION_TEXT = "v1.0.5";
+local VERSION_DATE = 1786200000;
 
 
 local addonName, addon = ...


### PR DESCRIPTION
## Important update for Patch 12.1:
- Fixed a critical issue where individual UIs (such as Merchant Frame and Delves Companion Frame) will not appear if they are brought up while the main game UI is hidden.
- Fixed an issue where the game constantly asked you to confirm "experimental camera features" when the Dialogue UI's quest window appears.

## Miscellaneous
- You can now Ctrl+Click a mount/pet reward to view it in the Dressing Room.