### PR TITLE
Block Unwanted Auto-pushed Quests

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -2314,6 +2314,15 @@ do  -- Chat Message
         end
         print(ADDON_ICON.." |cffffd100"..msg.."|r");
     end
+
+    function API.GenerateQuestLink(questID)
+        if questID and questID ~= 0 then
+            local questName = questID and API.GetQuestName(questID);
+            if questName then
+                return string.format("|cffffff00|Hquest:%s:0|h[%s]|h|r", questID, questName);
+            end
+        end
+    end
 end
 
 do  -- Tooltip

--- a/API.lua
+++ b/API.lua
@@ -2323,6 +2323,62 @@ do  -- Chat Message
             end
         end
     end
+
+
+	local CustomLinkUtil = {};
+
+	function API.AddCustomLinkType(typeName, callback, colorCode)
+		CustomLinkUtil[typeName] = {
+			callback = callback,
+			colorCode = colorCode,
+		};
+	end
+
+	function API.GenerateCustomLink(typeName, displayedText, ...)
+		if CustomLinkUtil[typeName] then
+			if not CustomLinkUtil.registered then
+				CustomLinkUtil.registered = true;
+				EventRegistry:RegisterCallback("SetItemRef", function(_, link, text, button, chatFrame)
+					if link then
+						local _typeName, subText = string.match(link, "dialogueui:([^:]+):([^|]+)");
+						if _typeName and CustomLinkUtil[_typeName] then
+							local args = {};
+							for arg in string.gmatch(subText, "[^:]+") do
+								table.insert(args, arg);
+							end
+							CustomLinkUtil[_typeName].callback(unpack(args));
+						end
+					end
+				end);
+			end
+
+			--|cffxxxxxx|Htype:payload|h[text]|h|r
+			local args = {...};
+			local link = "|Haddon:dialogueui:"..typeName;
+
+			if #args == 0 then
+				-- There must be at least 1 arg
+				args = {0};
+			end
+
+			for i, v in ipairs(args) do
+				link = link..":"..v;
+			end
+
+			link = string.format("|cff%s%s|h[%s]|h|r", CustomLinkUtil[typeName].colorCode or "ffd100", link, displayedText);
+
+			return link
+		end
+	end
+
+    function API.ShowBlockedQuestMessage(questID)
+        local questLink = API.GenerateQuestLink(questID);
+        if questLink then
+            local addonActionLink = API.GenerateCustomLink("UnblockQuest", L["Click To Unblock Quest"], questID);
+            local msg = string.format(L["Block Auto Pushed Quest Alert Format"], questLink).." "..addonActionLink;
+            print(ADDON_ICON.."|cffffffff"..msg.."|r");
+        end
+    end
 end
 
 do  -- Tooltip

--- a/Code/Core.lua
+++ b/Code/Core.lua
@@ -142,6 +142,8 @@ function EL:OnEvent(event, ...)
         return
     end
 
+    --print(event, GetTimePreciseSec(), ...);    --debug
+
     if event == "GOSSIP_SHOW" then
         self.lastEvent = event;
         local handler = GetCustomGossipHandler(...);
@@ -199,14 +201,30 @@ function EL:OnEvent(event, ...)
             return
 		end
 
-        if USE_AUTO_QUEST_POPUP and QuestIsFromAreaTrigger() and (QuestGetAutoAccept() or InCombatLockdown()) then
-            --"QuestIsFromAreaTrigger" and "QuestGetAutoAccept" Doesn't work in Classic
-            --Some quests that triggered upon login aren't "QuestIsFromAreaTrigger"
-            addon.WidgetManager:AddAutoQuestPopUp();
-            CloseQuest();
-        else
-            MainFrame:ShowUI(event, questStartItemID);
+        if QuestIsFromAreaTrigger() then
+            local declinedTimes = GetQuestDeclinedTimes();
+            if declinedTimes then
+                if declinedTimes == 1 then
+                    local isReroutedQuest = true;
+                    addon.WidgetManager:AddAutoQuestPopUp(nil, isReroutedQuest);
+                else
+                    FlagQuestDeclined();
+                    if declinedTimes < 3 then
+                        API.ShowBlockedQuestMessage(GetQuestID());
+                    end
+                    CloseQuest();
+                end
+                return
+            elseif USE_AUTO_QUEST_POPUP and (QuestGetAutoAccept() or InCombatLockdown()) then
+                --"QuestIsFromAreaTrigger" and "QuestGetAutoAccept" Doesn't work in Classic
+                --Some quests that triggered upon login aren't "QuestIsFromAreaTrigger"
+                addon.WidgetManager:AddAutoQuestPopUp();
+                CloseQuest();
+                return
+            end
         end
+
+        MainFrame:ShowUI(event, questStartItemID);
 
     elseif event == "QUEST_PROGRESS" or event == "QUEST_COMPLETE" or event == "QUEST_GREETING" then
         --Sometimes QUEST_FINISHED fires before QUEST_COMPLETE
@@ -223,8 +241,6 @@ function EL:OnEvent(event, ...)
             Muter:UpdateForInstance();
         end
     end
-
-    --print(event, GetTimePreciseSec(), ...);    --debug
 end
 
 function EL:ListenEvents(state)

--- a/Code/Core.lua
+++ b/Code/Core.lua
@@ -57,6 +57,36 @@ if not addon.IsToCVersionEqualOrNewerThan(50000) then
     end
 end
 
+local DeclinedQuests = {};
+
+local function FlagQuestDeclined()
+    local questID = GetQuestID();
+    if questID and questID ~= 0 then
+        if DeclinedQuests[questID] then
+            DeclinedQuests[questID] = DeclinedQuests[questID] + 1;
+        else
+            DeclinedQuests[questID] = 1;
+        end
+    end
+end
+addon.FlagQuestDeclined = FlagQuestDeclined;
+
+API.AddCustomLinkType("UnblockQuest", function(questID)
+    questID = questID and tonumber(questID);
+    if questID and DeclinedQuests[questID] then
+        DeclinedQuests[questID] = nil;
+        API.PrintMessage(addon.L["Quest Unblocked Alert"]);
+    end
+end);
+
+local function GetQuestDeclinedTimes()
+    -- Only affect area triggered quests
+    local questID = GetQuestID();
+    if questID and questID ~= 0 then
+        return DeclinedQuests[questID]
+    end
+end
+
 local function ShouldMuteQuest()
     local questID = GetQuestID();
     return ShouldMuteQuestDetail(questID)

--- a/Code/Dialogue/DialogueUI.lua
+++ b/Code/Dialogue/DialogueUI.lua
@@ -2380,6 +2380,8 @@ function DUIDialogBaseMixin:HideUI(cancelPopupFirst, fromPressingKey)
         return
     end
 
+    addon.FlagQuestDeclined();
+
     self:Hide();
 end
 
@@ -2512,6 +2514,7 @@ end
 
 function DUIDialogBaseMixin:OnMouseUp(button)
     if button == "RightButton" and GetDBBool("RightClickToCloseUI") and self:IsMouseMotionFocus() then
+        addon.FlagQuestDeclined();
         self:Hide();
     end
 end

--- a/Code/Dialogue/UITemplates.lua
+++ b/Code/Dialogue/UITemplates.lua
@@ -188,6 +188,7 @@ local function OnClickFunc_DeclineQuest(exitButton)
 end
 
 local function OnClickFunc_CloseQuest(exitButton)
+    addon.FlagQuestDeclined();
     CloseQuest();
     exitButton.owner:HideUI();
 end

--- a/Code/Widget/Widget_QuestPopup.lua
+++ b/Code/Widget/Widget_QuestPopup.lua
@@ -144,6 +144,16 @@ do
     function QuestPopupFrameMixin:OnHide()
         --QuestAlert is child of UIParent, but we don't want to trigger anything is the Frame becomes hidden due to UIParent
         self.Highlight:Hide();
+        self.questChanged = true;
+    end
+
+    function QuestPopupFrameMixin:OnEvent(event, ...)
+        if event == "QUEST_FINISHED" then
+            local questID = GetQuestID();
+            if self.isReroutedQuest and ((not questID) or questID ~= self.questID) then
+               self:Close();
+            end
+        end
     end
 
     function QuestPopupFrameMixin:SetTitle(title)
@@ -161,6 +171,10 @@ do
     end
 
     function QuestPopupFrameMixin:SetQuestDataByID(questID)
+        if questID ~= self.questID then
+            self.questChanged = true;
+        end
+
         self.questID = questID;
 
         if not QuestWidgets[questID] then
@@ -230,6 +244,17 @@ do
             if QuestWidgets[self.questID] == self then
                 QuestWidgets[self.questID] = nil;
             end
+
+            if self.isReroutedQuest then
+                self.isReroutedQuest = nil;
+                if GetQuestID() == self.questID then
+                    addon.FlagQuestDeclined();
+                    CloseQuest();
+                end
+            end
+
+            self.questID = nil;
+            self:UnregisterEvent("QUEST_FINISHED");
         end
     end
 
@@ -259,21 +284,35 @@ do
     end
 
     --For different Quest Types
-    function QuestPopupFrameMixin:SetQuestOffer(questID, questStartItemID)
+    function QuestPopupFrameMixin:SetQuestOffer(questID, questStartItemID, isReroutedQuest)
         self.method = "SetQuestOffer";
+        self.isReroutedQuest = isReroutedQuest;
+
         self:SetLayout("offer");
         if self:SetQuestDataByID(questID) then
             ThemeUtil:SetFontColor(self.Header, "DarkModeGrey70");
             ThemeUtil:SetFontColor(self.Title, "DarkModeGold");
             self.Header:SetText(L["New Quest Available"]);
             self.QuestIcon.AnimBounce:Play();
-            self:ShowCloseButton(false);
-            self.allowRightClickClose = false;
-            self:FadeIn();
+
+            local canBeClosed = isReroutedQuest or false;
+            self:ShowCloseButton(canBeClosed);
+            self.allowRightClickClose = canBeClosed;
+
+            if self.questChanged then
+                self.questChanged = nil;
+                self:FadeIn();
+            end
+
+            if isReroutedQuest then
+                self:RegisterEvent("QUEST_FINISHED");
+            else
+                self:UnregisterEvent("QUEST_FINISHED");
+            end
 
             if API.IsControllerMode() then
                 After(1, function()
-                    if not API.IsPlayerOnQuest(questID) then
+                    if (not API.IsPlayerOnQuest(questID)) and GetQuestID() == questID then
                         AcceptQuest();
                     end
                 end);
@@ -286,6 +325,7 @@ do
     function QuestPopupFrameMixin:SetAcceptedQuest(questID, questStartItemID)
         self.method = "SetAcceptedQuest";
         self:SetLayout("accepted");
+        self:UnregisterEvent("QUEST_FINISHED");
         if self:SetQuestDataByID(questID) then
             ThemeUtil:SetFontColor(self.Header, "DarkModeGrey70");
             ThemeUtil:SetFontColor(self.Title, "DarkModeGrey90");
@@ -312,6 +352,7 @@ do
         f:SetScript("OnLeave", f.OnLeave);
         f:SetScript("OnShow", f.OnShow);
         f:SetScript("OnHide", f.OnHide);
+        f:SetScript("OnEvent", f.OnEvent);
         f.widgetName = L["Auto Quest Popup"];
         return f
     end
@@ -344,12 +385,16 @@ do  --Create Popup
         return f
     end
 
-    function WidgetManager:AddAutoQuestPopUp(questStartItemID)
+    ---Add reroute the current Quest Detail to a popup, left click to view in DUI
+    ---@param questStartItemID number? payload from QUEST_DETAIL
+    ---@param isReroutedQuest boolean? Some quest are repeatedly pushed to the player unless they accept it (Uniting the Isles).
+    ---In such case, we add the quest to our popup but don't use Blizzard's popup API, otherwise the player will see another one in Objective Tracker
+    function WidgetManager:AddAutoQuestPopUp(questStartItemID, isReroutedQuest)
         --This method is called in Core.lua
         local questID = GetQuestID();
         if questID and questID ~= 0 then
             local popUpType = "OFFER";
-            if AddAutoQuestPopUp(questID, popUpType) then
+            if isReroutedQuest or AddAutoQuestPopUp(questID, popUpType) then
                 local f = QuestWidgets[questID];
                 if not f then
                     f = self:AcquireQuestPopup();
@@ -359,7 +404,7 @@ do  --Create Popup
                     f:SetAcceptedQuest(questID, questStartItemID);
                     self:UnregisterEvent("QUEST_ACCEPTED");
                 else
-                    f:SetQuestOffer(questID, questStartItemID);
+                    f:SetQuestOffer(questID, questStartItemID, isReroutedQuest);
                     self:RegisterEvent("QUEST_ACCEPTED");   --TO-DO: Unregister if player turns down the offer
                 end
 

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -307,6 +307,11 @@ L["BookUI TTS Voice Desc"] = "Use this voice for readable objects:";
 L["BookUI TTS Click To Read"] = "Click Paragraph To Read";
 L["BookUI TTS Click To Read Desc"] = "Click on a paragraph to read it.\n\nClick on a paragraph currently being read to stop reading.";
 
+--Quest Popups
+L["Block Auto Pushed Quest Alert Format"] = "Dialogue UI blocked an auto-pushed quest %s because you declined it twice this session.";
+L["Quest Unblocked Alert"] = "Quest unblocked. The quest window will appear the next time the game automatically offers you this quest.";
+L["Click To Unblock Quest"] = "Click to unblock";   --Will be used in a clickable link []
+
 --Keybinding Action
 L["Bound To"] = "Bound to: ";
 L["Hotkey Colon"] = "Hotkey: ";

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -305,6 +305,11 @@ L["BookUI TTS Voice Desc"] = "使用此声音朗读书籍：";
 L["BookUI TTS Click To Read"] = "点击以朗读段落";
 L["BookUI TTS Click To Read Desc"] = "左键点击某个段落来朗读它。\n\n左键点击正在被朗读的段落即可停止。";
 
+--Quest Popups
+L["Block Auto Pushed Quest Alert Format"] = "Dialogue UI 拦截了一个自动推送给你的任务 %s ，因为你最近已拒绝了它两次。";
+L["Quest Unblocked Alert"] = "已取消拦截此任务。任务界面将在下次游戏自动给你推送任务时显示。";
+L["Click To Unblock Quest"] = "点击以解除拦截";   --Will be used in a clickable link []
+
 --Keybinding Action
 L["Bound To"] = "绑定到：";
 L["Hotkey Colon"] = "快捷键：";


### PR DESCRIPTION
Certain quests like [Uniting the Isles](https://www.wowhead.com/quest=45727/uniting-the-isles) will be automatically offered to you repeatedly unless you accept them.

Annoying.

So, for this type of quest, we will:
- First time: Show the quest in full UI as usual.
- If the player have declined it, show the quest in a popup. They can left-click to view the quest details or right-click to decline it.
- The third time you are offered the quest, show an alert message in the chat window with the quest link and another hyperlink for "click to unblock".