### PR TITLE
Fix strength typo.

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -2787,7 +2787,7 @@ do  -- Tooltip
             dps = STAT_DPS_SHORT or "DPS",      --ITEM_MOD_DAMAGE_PER_SECOND_SHORT
             armor = RESISTANCE0_NAME or "Armor",
             stamina = SPELL_STAT3_NAME or "Stamina",
-            strength = SPELL_STAT1_NAME or "Strengh",
+            strength = SPELL_STAT1_NAME or "Strength",
             agility = SPELL_STAT2_NAME or "Agility",
             intellect = SPELL_STAT4_NAME or "Intellect",
             spirit = SPELL_STAT5_NAME or "Spirit",

--- a/Code/Camera.lua
+++ b/Code/Camera.lua
@@ -483,12 +483,12 @@ local function ZoomIn_FocusNPC_OnUpdate(self, elapsed)
     self.t = self.t + elapsed;
 
     local pitch = Esaing_OutSine(self.t, 88,  15, CAMERA_MOVEMENT_DURATION);
-    local targetStrengh = Esaing_OutSine(self.t, 0.0, FOCUS_STRENGTH_PITCH, CAMERA_MOVEMENT_DURATION);
+    local targetStrength = Esaing_OutSine(self.t, 0.0, FOCUS_STRENGTH_PITCH, CAMERA_MOVEMENT_DURATION);
 
     if self.t >= CAMERA_MOVEMENT_DURATION then
         ConsoleExec("pitchlimit "..15);
         pitch = 88;
-        targetStrengh = FOCUS_STRENGTH_PITCH;
+        targetStrength = FOCUS_STRENGTH_PITCH;
         self:SetScript("OnUpdate", nil);
     end
 
@@ -496,7 +496,7 @@ local function ZoomIn_FocusNPC_OnUpdate(self, elapsed)
         ZoomIn_Fov_OnUpdate(self, elapsed);
     end
 
-    SetCVar("test_cameraTargetFocusInteractStrengthPitch", targetStrengh);
+    SetCVar("test_cameraTargetFocusInteractStrengthPitch", targetStrength);
     ConsoleExec("pitchlimit "..pitch);
 end
 

--- a/Code/Scroll/Scroll_EasySmooth.lua
+++ b/Code/Scroll/Scroll_EasySmooth.lua
@@ -207,15 +207,15 @@ do
         end
     end
 
-    function ScrollFrameMixin:SteadyScroll(strengh)
-        --For Joystick: strengh -1 ~ +1
+    function ScrollFrameMixin:SteadyScroll(strength)
+        --For Joystick: strength -1 ~ +1
 
-        if strengh > 0.8 then
-            self.scrollSpeed = 80 + 600 * (strengh - 0.8);
-        elseif strengh < -0.8 then
-            self.scrollSpeed = -80 + 600 * (strengh + 0.8);
+        if strength > 0.8 then
+            self.scrollSpeed = 80 + 600 * (strength - 0.8);
+        elseif strength < -0.8 then
+            self.scrollSpeed = -80 + 600 * (strength + 0.8);
         else
-            self.scrollSpeed = 100 * strengh
+            self.scrollSpeed = 100 * strength
         end
 
         if not self.isSteadyScrolling then

--- a/Code/Scroll/Scroll_Swipe.lua
+++ b/Code/Scroll/Scroll_Swipe.lua
@@ -12,7 +12,7 @@ local EMULATE_SWIPE = true;
 local SWIPE_SPEED_SAMPLE_T = 2/60;
 local SWIPE_START_THRESHOLD = 25;   --Distance Square
 local RUBBERBAND_MAX_OFFSET = 64;
-local RUBBERBAND_STRENGH = 0.5;
+local RUBBERBAND_STRENGTH = 0.5;
 
 local function CalculateOffset(offset, range)
     if offset > 0 and offset < range then
@@ -20,9 +20,9 @@ local function CalculateOffset(offset, range)
     end
 
     if offset < 0 then
-        return  0 -((1 - (1 / (((0 - offset) * RUBBERBAND_STRENGH / RUBBERBAND_MAX_OFFSET) + 1))) * RUBBERBAND_MAX_OFFSET)
+        return  0 -((1 - (1 / (((0 - offset) * RUBBERBAND_STRENGTH / RUBBERBAND_MAX_OFFSET) + 1))) * RUBBERBAND_MAX_OFFSET)
     elseif offset > range then
-        return  range + ((1 - (1 / (((offset - range) * RUBBERBAND_STRENGH / RUBBERBAND_MAX_OFFSET) + 1))) * RUBBERBAND_MAX_OFFSET)
+        return  range + ((1 - (1 / (((offset - range) * RUBBERBAND_STRENGTH / RUBBERBAND_MAX_OFFSET) + 1))) * RUBBERBAND_MAX_OFFSET)
     end
 end
 

--- a/Locales/deDE.lua
+++ b/Locales/deDE.lua
@@ -347,7 +347,7 @@ L["Abbrev Breakpoint 1000"] = FIRST_NUMBER_CAP_NO_SPACE or "T";    --1,000 = 1K
 L["Abbrev Breakpoint 10000"] = FIRST_NUMBER_CAP_NO_SPACE or "K";    --Reserved for Asian languages that have words for 10,000
 L["Match Stat Armor"] = "([,%d%.]+) Rüstung";
 L["Match Stat Stamina"] = "([,%d%.]+) Ausdauer";
-L["Match Stat Strengh"] = "([,%d%.]+) Stärke";
+L["Match Stat Strength"] = "([,%d%.]+) Stärke";
 L["Match Stat Agility"] = "([,%d%.]+) Beweglichkeit";
 L["Match Stat Intellect"] = "([,%d%.]+) Intelligenz";
 L["Match Stat Spirit"] = "([,%d%.]+) Willenskraft";

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -357,7 +357,7 @@ L["Abbrev Breakpoint 1000"] = FIRST_NUMBER_CAP_NO_SPACE or "K";     --1,000 = 1K
 L["Abbrev Breakpoint 10000"] = FIRST_NUMBER_CAP_NO_SPACE or "K";    --Reserved for Asian languages that have words for 10,000
 L["Match Stat Armor"] = "([,%d%.]+) Armor";
 L["Match Stat Stamina"] = "([,%d%.]+) Stamina";
-L["Match Stat Strengh"] = "([,%d%.]+) Strengh";
+L["Match Stat Strength"] = "([,%d%.]+) Strength";
 L["Match Stat Agility"] = "([,%d%.]+) Agility";
 L["Match Stat Intellect"] = "([,%d%.]+) Intellect";
 L["Match Stat Spirit"] = "([,%d%.]+) Spirit";

--- a/Locales/esES.lua
+++ b/Locales/esES.lua
@@ -347,7 +347,7 @@ L["Abbrev Breakpoint 1000"] = FIRST_NUMBER_CAP_NO_SPACE or "K";     --1,000 = 1K
 L["Abbrev Breakpoint 10000"] = FIRST_NUMBER_CAP_NO_SPACE or "K";    --Reserved for Asian languages that have words for 10,000
 L["Match Stat Armor"] = "([,%d%.]+) armadura";
 L["Match Stat Stamina"] = "([,%d%.]+) aguante";
-L["Match Stat Strengh"] = "([,%d%.]+) fuerza";
+L["Match Stat Strength"] = "([,%d%.]+) fuerza";
 L["Match Stat Agility"] = "([,%d%.]+) agilidad";
 L["Match Stat Intellect"] = "([,%d%.]+) intelecto";
 L["Match Stat Spirit"] = "([,%d%.]+) espíritu";

--- a/Locales/esMX.lua
+++ b/Locales/esMX.lua
@@ -201,7 +201,7 @@ L["Instruction Open Settings Console"] = "Para abrir Ajustes, presiona [KEY:PC:F
 --DO NOT TRANSLATE
 L["Match Stat Armor"] = "([,%d%.]+) p. de armadura";
 L["Match Stat Stamina"] = "([,%d%.]+) Aguante";
-L["Match Stat Strengh"] = "([,%d%.]+) Fuerza";
+L["Match Stat Strength"] = "([,%d%.]+) Fuerza";
 L["Match Stat Agility"] = "([,%d%.]+) Agilidad";
 L["Match Stat Intellect"] = "([,%d%.]+) Intelecto";
 L["Match Stat Spirit"] = "([,%d%.]+) Espíritu";

--- a/Locales/frFR.lua
+++ b/Locales/frFR.lua
@@ -352,7 +352,7 @@ L["Abbrev Breakpoint 1000"] = FIRST_NUMBER_CAP_NO_SPACE or "K";     --1,000 = 1K
 L["Abbrev Breakpoint 10000"] = FIRST_NUMBER_CAP_NO_SPACE or "K";    --Reserved for Asian languages that have words for 10,000
 L["Match Stat Armor"] = "Armure : ([,%d%.%-]+)";
 L["Match Stat Stamina"] = "([,%d%.%-]+) Endurance";
-L["Match Stat Strengh"] = "([,%d%.%-]+) Force";
+L["Match Stat Strength"] = "([,%d%.%-]+) Force";
 L["Match Stat Agility"] = "([,%d%.%-]+) Agilité";
 L["Match Stat Intellect"] = "([,%d%.%-]+) Intelligence";
 L["Match Stat Spirit"] = "([,%d%.%-]+) Esprit";

--- a/Locales/itIT.lua
+++ b/Locales/itIT.lua
@@ -13,7 +13,7 @@ L["Renown Level Label"] = "Fama ";
 --[[
 L["Match Stat Armor"] = "([,%d%.]+) Armor";
 L["Match Stat Stamina"] = "([,%d%.]+) Stamina";
-L["Match Stat Strengh"] = "([,%d%.]+) Strengh";
+L["Match Stat Strength"] = "([,%d%.]+) Strength";
 L["Match Stat Agility"] = "([,%d%.]+) Agility";
 L["Match Stat Intellect"] = "([,%d%.]+) Intellect";
 L["Match Stat Spirit"] = "([,%d%.]+) Spirit";

--- a/Locales/koKR.lua
+++ b/Locales/koKR.lua
@@ -348,7 +348,7 @@ L["Abbrev Breakpoint 1000"] = "천";     --1,000 = 1K
 L["Abbrev Breakpoint 10000"] = "만";    --Reserved for Asian languages that have words for 10,000
 L["Match Stat Armor"] = "방어도 ([,%d%.]+)";
 L["Match Stat Stamina"] = " 체력 %+([,%d%.]+)";
-L["Match Stat Strengh"] = "힘 %+([,%d%.]+)";
+L["Match Stat Strength"] = "힘 %+([,%d%.]+)";
 L["Match Stat Agility"] = "민첩성 %+([,%d%.]+)";
 L["Match Stat Intellect"] = "지능 %+([,%d%.]+)";
 L["Match Stat Spirit"] = "정신력 %+([,%d%.]+)";

--- a/Locales/ptBR.lua
+++ b/Locales/ptBR.lua
@@ -348,7 +348,7 @@ L["Abbrev Breakpoint 1000"] = FIRST_NUMBER_CAP_NO_SPACE or "K";     --1,000 = 1K
 L["Abbrev Breakpoint 10000"] = FIRST_NUMBER_CAP_NO_SPACE or "K";    --Reserved for Asian languages that have words for 10,000
 L["Match Stat Armor"] = "([,%d%.]+) de Armadura";
 L["Match Stat Stamina"] = "([,%d%.]+) Vigor";
-L["Match Stat Strengh"] = "([,%d%.]+) Força";
+L["Match Stat Strength"] = "([,%d%.]+) Força";
 L["Match Stat Agility"] = "([,%d%.]+) Agilidade";
 L["Match Stat Intellect"] = "([,%d%.]+) Intelecto";
 L["Match Stat Spirit"] = "([,%d%.]+) Espírito";

--- a/Locales/ruRU.lua
+++ b/Locales/ruRU.lua
@@ -347,7 +347,7 @@ L["Abbrev Breakpoint 1000"] = "Т";     --1,000 = 1K
 L["Abbrev Breakpoint 10000"] = "Т";    --Reserved for Asian languages that have words for 10,000
 L["Match Stat Armor"] = "Броня: ([,%d%.]+)";
 L["Match Stat Stamina"] = "([,%d%.]+) к выносливости";
-L["Match Stat Strengh"] = "([,%d%.]+) к силе";
+L["Match Stat Strength"] = "([,%d%.]+) к силе";
 L["Match Stat Agility"] = "([,%d%.]+) к ловкости";
 L["Match Stat Intellect"] = "([,%d%.]+) к интеллекту";
 L["Match Stat Spirit"] = "([,%d%.]+) к духу";

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -355,7 +355,7 @@ L["Abbrev Breakpoint 1000"] = "千";     --1,000 = 1K
 L["Abbrev Breakpoint 10000"] = "万";    --Reserved for Asian languages that have words for 10,000
 L["Match Stat Armor"] = "([,%d%.]+)点护甲";
 L["Match Stat Stamina"] = "([,%d%.]+) 耐力";
-L["Match Stat Strengh"] = "([,%d%.]+) 力量";
+L["Match Stat Strength"] = "([,%d%.]+) 力量";
 L["Match Stat Agility"] = "([,%d%.]+) 敏捷";
 L["Match Stat Intellect"] = "([,%d%.]+) 智力";
 L["Match Stat Spirit"] = "([,%d%.]+) 精神";

--- a/Locales/zhTW.lua
+++ b/Locales/zhTW.lua
@@ -14,7 +14,7 @@ L["Abbrev Breakpoint 1000"] = "千";     --1,000 = 1K
 L["Abbrev Breakpoint 10000"] = "萬";    --Reserved for Asian languages that have words for 10,000
 L["Match Stat Armor"] = "([,%d%.]+)點護甲";
 L["Match Stat Stamina"] = "([,%d%.]+)耐力";     --No Space!
-L["Match Stat Strengh"] = "([,%d%.]+)力量";
+L["Match Stat Strength"] = "([,%d%.]+)力量";
 L["Match Stat Agility"] = "([,%d%.]+)敏捷";
 L["Match Stat Intellect"] = "([,%d%.]+)智力";
 L["Match Stat Spirit"] = "([,%d%.]+)精神";


### PR DESCRIPTION
Fixes #208.

To fix the comparison tooltip bug, only the pattern in enUS.lua line 360 is necessary, but the typo is now fixed everywhere.