### PR TITLE
1.0.5 e

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -848,7 +848,7 @@ do  -- NPC Interaction
         local name = UnitName("npc");
         local creatureID = GetCreatureIDFromGUID(UnitGUID("npc"));
         if creatureID then
-            name = name or "";
+            name = canaccessvalue(name) and name or "";
             return name, creatureID
         end
     end

--- a/Code/GossipData/GossipData_AutoSelect.lua
+++ b/Code/GossipData/GossipData_AutoSelect.lua
@@ -11,6 +11,7 @@ local AutoSelectGossip = {
 	[138824] = 1,			--Ritual Site Reports
     [136045] = 1,           --(Quest) Let's spar! Armies of Darkness
     [135188] = 1,           --(Quest) Vyrin wants you to join him at Saltheril's Haven. Silvermoon "Trader"
+    [141839] = 1,           --<Recite from the Corrosive Codex.>
 
     --Den of Nalorakk
     [135009] = 1,           --Ethereal Pyre, teleport from entrance to the start of the first area
@@ -35,6 +36,8 @@ local AutoSelectGossip = {
     [134669] = 1,           --(Quest) I'll take the devices into the portal and shut them down!
     [135239] = 1,           --(Quest) Alright... pardon! I'll just step around you...
     [138009] = 1,           --(Quest) I will re-align the conduits and restore the energy.
+    [138690] = 1,           --(Delve) Disrupt the summon? I've got ideas...
+    [139635] = 1,           --They'll never know what hit them. Artolla
 
     [48598] = true,         --I'd like to check my mail.   [NPC: 132969] Katy Stampwhistle
     [55193] = true,         --Mail [NPC: 191869] Child of Ohn'ahra

--- a/Code/GossipData/GossipData_Racing.lua
+++ b/Code/GossipData/GossipData_Racing.lua
@@ -334,6 +334,10 @@ local function ProcessFunc(auraInfo)
 end
 
 function DataSource:UpdateRaceTimesFromAura()
+    if C_Secrets and C_Secrets.ShouldAurasBeSecret and C_Secrets.ShouldAurasBeSecret() then
+        return;
+    end
+
     local unit = "player";
     local filter = "HELPFUL";
     local usePackedAura = true;

--- a/Code/GossipData/GossipData_Racing.lua
+++ b/Code/GossipData/GossipData_Racing.lua
@@ -48,6 +48,9 @@ function DataSource:OnInteractWithNPC(creatureName)
         end
         self:SetScript("OnEvent", self.OnEvent);
         self:RegisterUnitEvent("UNIT_AURA", "player");
+        if C_EventUtils.IsEventValid("ADDON_RESTRICTION_STATE_CHANGED") then
+            self:UnregisterEvent("ADDON_RESTRICTION_STATE_CHANGED");
+        end
         self:ResetQueryCounter();
         self:UpdateRaceTimesFromAura();
         self.active = true;
@@ -78,6 +81,14 @@ function DataSource:OnEvent(event, ...)
         local dataInstanceID = ...
         if dataInstanceID == self.dataInstanceID then
             self:UpdateRaceTimesFromAura();
+        end
+    elseif event == "ADDON_RESTRICTION_STATE_CHANGED" then
+        if not self.pauseUpdate then
+            self.pauseUpdate = true;
+            C_Timer.After(0.2, function()
+                self.pauseUpdate = nil;
+                self:UpdateRaceTimesFromAura();
+            end);
         end
     end
 end
@@ -319,6 +330,9 @@ function DataSource:PostDataFullyRetrieved()
     self.auraInstanceID = nil;
     self:UnregisterEvent("UNIT_AURA");
     self:UnregisterEvent("TOOLTIP_DATA_UPDATE");
+    if C_EventUtils.IsEventValid("ADDON_RESTRICTION_STATE_CHANGED") then
+        self:UnregisterEvent("ADDON_RESTRICTION_STATE_CHANGED");
+    end
     self:SetScript("OnUpdate", nil);
     self:SetScript("OnEvent", nil);
 end

--- a/Code/Utility/TTS.lua
+++ b/Code/Utility/TTS.lua
@@ -174,7 +174,10 @@ function TTSUtil:GetVoiceIDForNPC()
     local voiceID;
     --added questnpc for remote quests
     if UnitExists("questnpc") or UnitExists("npc") then
-        local unitSex = UnitSex("questnpc") or UnitSex("npc")
+        local unitSex = UnitSex("questnpc") or UnitSex("npc");
+        if not addon.API.canaccessvalue(unitSex) then
+            unitSex = 2;
+        end
         if unitSex == 2 then
             voiceID = self:GetDefaultVoiceA();
         elseif unitSex == 3 then

--- a/Code/Widget/WidgetManager.lua
+++ b/Code/Widget/WidgetManager.lua
@@ -23,6 +23,13 @@ local WidgetManager = CreateFrame("Frame");
 addon.WidgetManager = WidgetManager;
 
 
+local function ConvertFrameAnchorToCenter(frame)
+    local x, y = frame:GetCenter();
+    frame:ClearAllPoints();
+    frame:SetPoint("CENTER", nil, "BOTTOMLEFT", x, y);
+end
+
+
 local DragFrame = CreateFrame("Frame");
 do  --Emulate Drag gesture
     function DragFrame:StopWatching()
@@ -51,6 +58,10 @@ do  --Emulate Drag gesture
 
                 if self.owner.OnDragStop then
                     self.owner:OnDragStop();
+                end
+
+                if self.owner.useCenterAsOrigin then
+                    ConvertFrameAnchorToCenter(self.owner);
                 end
             end
             self.owner.isMoving = nil;

--- a/Code/Widget/Widget_QuickSlot.lua
+++ b/Code/Widget/Widget_QuickSlot.lua
@@ -421,6 +421,14 @@ do  --QuestRewardItemButtonMixin
         WidgetManager.WidgetBaseMixin.SavePosition(self);
     end
 
+    function QuestRewardItemButtonMixin:OnDragStart()
+        -- Left empty to override original OnDragStart
+    end
+
+    function QuestRewardItemButtonMixin:OnDragStop()
+        -- Left empty to override original OnDragStop
+    end
+
     function QuestRewardItemButtonMixin:OnItemEquipped()
         self:ShowUpgradeIcon(false);
         self:SetCountdown(COUNTDOWN_COMPLETE_MANUAL, true);

--- a/Initialization.lua
+++ b/Initialization.lua
@@ -1,5 +1,5 @@
-local VERSION_TEXT = "v1.0.5 d";
-local VERSION_DATE = 1787400000;
+local VERSION_TEXT = "v1.0.5 e";
+local VERSION_DATE = 1788000000;
 
 
 local addonName, addon = ...


### PR DESCRIPTION
- Fixed an issue where the Skyriding NPC didn't respond to interaction if you were in combat. #215 
- Fixed a Text-to-Speech-related error that occurred when you interacted with an NPC while in combat.
- Fixed an issue where the Valuable Reward Popup failed to align to its center after being dragged. #213 